### PR TITLE
Beta Navigation - More Functionality

### DIFF
--- a/src/locator/al-route.types.ts
+++ b/src/locator/al-route.types.ts
@@ -13,18 +13,21 @@ import { AlLocatorService } from './al-locator.service';
  */
 export interface AlRoutingHost
 {
-    /* Exposes the effective navigation schema, if available (not required). */
-    schema?:AlNavigationSchema;
-
     /* Exposes the current URL of the application (required). */
     currentUrl:string;
+
+    /* @deprecated Exposes the effective navigation schema, if available (not required).  Don't use this! */
+    schema?:AlNavigationSchema;
 
     /* Routing parameters */
     routeParameters: {[parameter:string]:string};
     setRouteParameter( parameter:string, value:string ):void;
     deleteRouteParameter( parameter:string ):void;
 
-    /* Bookmarks */
+    /* Named routes - actions that can be reused by multiple menu items or invoked imperatively from code */
+    getRouteByName?( routeName:string ):AlRouteDefinition;
+
+    /* Bookmarks - arguably the worst name for a navigation construct I've chosen in years!  But super useful, I swear. */
     setBookmark( bookmarkId:string, route:AlRoute );
     getBookmark( bookmarkId:string ):AlRoute;
 
@@ -459,8 +462,11 @@ export class AlRoute {
      */
     getRouteAction():AlRouteAction {
         if ( typeof( this.definition.action ) === 'string' ) {
-            if ( this.host.schema && this.host.schema.namedRoutes && this.host.schema.namedRoutes.hasOwnProperty( this.definition.action ) ) {
-                return this.host.schema.namedRoutes[this.definition.action].action as AlRouteAction;
+            if ( typeof( this.host.getRouteByName ) === 'function' ) {
+                const definition:AlRouteDefinition = this.host.getRouteByName( this.definition.action );
+                if ( definition && definition.action ) {
+                    return definition.action as AlRouteAction;
+                }
             }
             return null;
         } else if ( typeof( this.definition.action ) === 'object' ) {

--- a/test/al-locator.spec.ts
+++ b/test/al-locator.spec.ts
@@ -39,8 +39,8 @@ describe( 'AlLocatorMatrix', () => {
         } );
 
         it( "should escape uri patterns in the expected way", () => {
-            expect( locator.escapeLocationPattern( "https://console.overview.alertlogic.com" ) ).to.equal( "^https:\\/\\/console\\.overview\\.alertlogic\\.com.*$" );
-            expect( locator.escapeLocationPattern( "https://dashboards.pr-*.ui-dev.alertlogic.com" ) ).to.equal( "^https:\\/\\/dashboards\\.pr\\-[a-zA-Z0-9_]+\\.ui\\-dev\\.alertlogic\\.com.*$" );
+            expect( locator['escapeLocationPattern']( "https://console.overview.alertlogic.com" ) ).to.equal( "^https:\\/\\/console\\.overview\\.alertlogic\\.com.*$" );
+            expect( locator['escapeLocationPattern']( "https://dashboards.pr-*.ui-dev.alertlogic.com" ) ).to.equal( "^https:\\/\\/dashboards\\.pr\\-[a-zA-Z0-9_]+\\.ui\\-dev\\.alertlogic\\.com.*$" );
         } );
 
         it( "should properly resolve URI patterns to location nodes", () => {
@@ -53,14 +53,26 @@ describe( 'AlLocatorMatrix', () => {
             expect( node.locTypeId ).to.equal( AlLocation.OverviewUI );
 
             //  Make sure that aliased nodes work, and return a node with the URI pointing to themselves
-            const aliasNodeURL = "https://incidents-pr-12.ui-dev.product.dev.alertlogic.com/#/summary/12345678?aaid=12345678&locid=defender-uk-newport";
-            const aliasNodeBase = "https://incidents-pr-12.ui-dev.product.dev.alertlogic.com";
+            let aliasNodeURL = "https://incidents-pr-12.ui-dev.product.dev.alertlogic.com/#/summary/12345678?aaid=12345678&locid=defender-uk-newport";
+            let aliasNodeBase = "https://incidents-pr-12.ui-dev.product.dev.alertlogic.com";
             node = locator.getNodeByURI( aliasNodeURL );
             expect( node ).to.be.an( "object" );
             expect( node.environment ).to.equal( "integration" );
             expect( node.residency ).to.equal( undefined );
             expect( node.locTypeId ).to.equal( AlLocation.IncidentsUI );
             expect( node._fullURI ).to.equal( aliasNodeBase );
+            expect( node.uri ).to.equal( aliasNodeBase );
+
+            aliasNodeURL = "https://console.incidents.product.dev.alertlogic.com/#/summary/12345678?aaid=12345678&locid=defender-uk-newport";
+            aliasNodeBase = "https://console.incidents.product.dev.alertlogic.com";
+            let node2 = locator.getNodeByURI( aliasNodeURL );
+            expect( node2 ).to.be.an( "object" );
+            expect( node ).to.equal( node2 );
+            expect( node.environment ).to.equal( "integration" );
+            expect( node.residency ).to.equal( undefined );
+            expect( node.locTypeId ).to.equal( AlLocation.IncidentsUI );
+            expect( node._fullURI ).to.equal( aliasNodeBase );
+            expect( node.uri ).to.equal( aliasNodeBase );
         } );
 
         it( "should propertly identify the acting node from the acting URL passed to the constructor", () => {


### PR DESCRIPTION
- Exposed general purpose 'resolveURL' method on AlLocatorService.
  This simply takes a location ID, a path, and a context and spits out a URL.
- Restructured AlLocatorMatrix's methods to move public functions to the
  top and moved/mark protected internal functionality.
- Exposed additional (optional) method on AlNavigationHost interface,
  allowing for multiple schemas to be loaded and available at the same time.
- When an aliased domain is detected as the actor (e.g., *pipeline demo
  buckets*), that domain "takes over" the node's canonical URL for the
  duration of execution time.
- Supporting unit tests