### PR TITLE
Beta-Navigation Environment Support

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -27,7 +27,8 @@ module.exports = function (config) {
       },
       compilerOptions: {
         lib: [
-          "es2015",
+          "es6",
+          "es2017",
           "dom"
         ],
         esModuleInterop: true

--- a/src/errors/al-error.types.ts
+++ b/src/errors/al-error.types.ts
@@ -25,8 +25,8 @@ export class AlAPIServerError extends Error
  */
 export class AlResponseValidationError extends Error
 {
-    constructor( message:string, errors:any[] = [] ) {
-        console.error( message, errors );
+    constructor( message:string, public errors:any[] = [] ) {
         super( message );
+        console.error( message, errors );
     }
 }

--- a/src/locator/al-location.dictionary.ts
+++ b/src/locator/al-location.dictionary.ts
@@ -20,15 +20,7 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         productType: 'insight',
         aspect: 'api',
         uri: 'https://api.global-integration.product.dev.alertlogic.com',
-        environment: 'integration'
-    },
-    {
-        locTypeId: AlLocation.GlobalAPI,
-        insightLocationId: 'insight-global',
-        productType: 'insight',
-        aspect: 'api',
-        uri: 'https://api.global-integration.product.dev.alertlogic.com',
-        environment: 'development'
+        environment: 'integration|beta-navigation|development'
     },
 
     /**
@@ -42,7 +34,6 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         environment: 'production',
         residency: 'US'
     },
-
     {
         locTypeId: AlLocation.InsightAPI,
         productType: 'insight',
@@ -51,22 +42,13 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         environment: 'production',
         residency: 'EMEA'
     },
-
     {
         locTypeId: AlLocation.InsightAPI,
         productType: 'insight',
         aspect: 'api',
         uri: 'https://api.product.dev.alertlogic.com',
-        environment: 'integration',
+        environment: 'integration|beta-navigation|development',
         residency: 'US'
-    },
-
-    {
-        locTypeId: AlLocation.InsightAPI,
-        productType: 'insight',
-        aspect: 'api',
-        uri: 'https://api.product.dev.alertlogic.com',
-        environment: 'development'
     },
 
     /**
@@ -123,24 +105,9 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         productType: 'defender',
         aspect: 'ui',
         uri: 'https://cd-integration-console.alertlogic.net',
-        environment: 'integration',
+        environment: 'integration|beta-navigation|development',
         residency: 'US',
         uiCaption: 'us-east-1',
-        uiEntryPoint: {
-          locTypeId: AlLocation.OverviewUI,
-          path: '/#/'
-        }
-    },
-
-    {
-        locTypeId: AlLocation.LegacyUI,
-        insightLocationId: 'defender-us-ashburn',
-        productType: 'defender',
-        aspect: 'ui',
-        uri: 'https://cd-integration-console.alertlogic.net',
-        environment: 'development',
-        uiCaption: 'us-east-1',
-        residency: 'US',
         uiEntryPoint: {
           locTypeId: AlLocation.OverviewUI,
           path: '/#/'
@@ -184,12 +151,7 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
     {
         locTypeId: AlLocation.InsightBI,
         uri: 'https://bi.product.dev.alertlogic.com',
-        environment: 'integration'
-    },
-    {
-        locTypeId: AlLocation.InsightBI,
-        uri: 'https://bi.product.dev.alertlogic.com',
-        environment: 'development'
+        environment: 'integration|beta-navigation|development'
     },
 
     /**

--- a/src/locator/al-location.dictionary.ts
+++ b/src/locator/al-location.dictionary.ts
@@ -82,7 +82,7 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         residency: 'US',
         uiCaption: 'us-west-1',
         uiEntryPoint: {
-          site: AlLocation.OverviewUI,
+          locTypeId: AlLocation.OverviewUI,
           path: '/#/'
         }
     },
@@ -97,7 +97,7 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         residency: 'EMEA',
         uiCaption: 'uk-west-1',
         uiEntryPoint: {
-          site: AlLocation.OverviewUI,
+          locTypeId: AlLocation.OverviewUI,
           path: '/#/'
         }
     },
@@ -112,7 +112,7 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         residency: 'US',
         uiCaption: 'us-east-1',
         uiEntryPoint: {
-          site: AlLocation.OverviewUI,
+          locTypeId: AlLocation.OverviewUI,
           path: '/#/'
         }
     },
@@ -127,7 +127,7 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         residency: 'US',
         uiCaption: 'us-east-1',
         uiEntryPoint: {
-          site: AlLocation.OverviewUI,
+          locTypeId: AlLocation.OverviewUI,
           path: '/#/'
         }
     },
@@ -142,7 +142,7 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         uiCaption: 'us-east-1',
         residency: 'US',
         uiEntryPoint: {
-          site: AlLocation.OverviewUI,
+          locTypeId: AlLocation.OverviewUI,
           path: '/#/'
         }
     },

--- a/src/locator/al-locator.types.ts
+++ b/src/locator/al-locator.types.ts
@@ -77,13 +77,22 @@ export class AlLocation
                 locTypeId: locTypeId,
                 environment: 'production',
                 residency: 'US',
-                uri: `https://console.${appCode}.alertlogic.com`
+                uri: `https://console.${appCode}.alertlogic.com`,
+                keyword: appCode
             },
             {
                 locTypeId: locTypeId,
                 environment: 'production',
                 residency: 'EMEA',
-                uri: `https://console.${appCode}.alertlogic.co.uk`
+                uri: `https://console.${appCode}.alertlogic.co.uk`,
+                keyword: appCode
+            },
+            {
+                locTypeId: locTypeId,
+                environment: 'beta-navigation',
+                residency: 'US',
+                uri: `https://${appCode}-beta-navigation.ui-dev.product.dev.alertlogic.com`,
+                keyword: appCode
             },
             {
                 locTypeId: locTypeId,
@@ -92,15 +101,16 @@ export class AlLocation
                 aliases: [
                     `https://${appCode}.ui-dev.product.dev.alertlogic.com`,
                     `https://${appCode}-*.ui-dev.product.dev.alertlogic.com`,
-                    `https://${appCode}-*-*.ui-dev.product.dev.alertlogic.com`,
-                    `https://${appCode}-*-*-*.ui-dev.product.dev.alertlogic.com`,
+                    `https://${appCode}-pr-*.ui-dev.product.dev.alertlogic.com`,
                     `https://*.o3-${appCode}.product.dev.alertlogic.com`
-                ]
+                ],
+                keyword: appCode
             },
             {
                 locTypeId: locTypeId,
                 environment: 'development',
-                uri: `http://localhost:${devPort}`
+                uri: `http://localhost:${devPort}`,
+                keyword: 'localhost'
             }
         ];
     }
@@ -113,7 +123,6 @@ export class AlLocation
 export interface AlLocationDescriptor
 {
     locTypeId:string;               //  This should correspond to one of the ALLocation string constants, e.g., AlLocation.AccountsUI or AlLocation.GlobalAPI.
-    parentId?:string;               //  If the given node is a child of another node, this is the parent's ID
     insightLocationId?:string;      //  The location ID as defined by the global locations service -- e.g., 'defender-us-ashburn' or 'insight-eu-ireland'.
     uri:string;                     //  URI of the entity
     residency?:string;              //  A data residency domain
@@ -124,10 +133,10 @@ export interface AlLocationDescriptor
     aspect?:string;                 //  'ui' or 'api'
 
     uiCaption?:string;
-    uiEntryPoint?:any;
+    uiEntryPoint?:{locTypeId:string, path?:string};
     data?:any;                      //  Miscellaneous associated data
-
-    _fullURI?:string;               //  Fully calculated URI of the node (for caching purposes)
+    weight?:number;                 //  Relative weight for resolution by URI.  In general, the more significant a node is the lower its weight should be.
+    keyword?:string;                //
 }
 
 /**
@@ -164,14 +173,24 @@ export const AlInsightLocations: {[locationId:string]: ({residency: string; resi
     }
 };
 
+type UriMappingItem =
+{
+    location:AlLocationDescriptor,
+    matcher?:RegExp,
+    matchExpression:string
+};
+
 export class AlLocatorMatrix
 {
+    public static totalTime;
+    public static totalSeeks = 0;
+
     protected actingUri:string|null = null;
     protected actor:AlLocationDescriptor|null = null;
 
-    protected uriMap:{[pattern:string]:{matcher:RegExp,location:AlLocationDescriptor}} = {};
+    protected uriMap:{[pattern:string]:UriMappingItem[]} = {};
     protected nodes:{[locTypeId:string]:AlLocationDescriptor} = {};
-    protected _nodeMap:{[hashKey:string]:AlLocationDescriptor} = {};
+    protected nodeDictionary:{[hashKey:string]:AlLocationDescriptor} = {};
 
     protected context:AlLocationContext = {
         environment:        "production",
@@ -201,8 +220,14 @@ export class AlLocatorMatrix
         const loc = this.getNode( locTypeId, context );
         let url:string;
         if ( loc ) {
-            url = this.resolveNodeURI( loc );
+            url = loc.uri;
+            //  For historical reasons, some nodes (like auth0) are represented without protocols (e.g., alertlogic-integration.auth0.com instead of https://alertlogic-integration.auth0.com).
+            //  For the purposes of resolving functional links, detect these protocolless domains and add the default https:// protocol to them.
+            if ( url.indexOf("http") !== 0 ) {
+                url = `https://${url}`;
+            }
         } else {
+            /* istanbul ignore else */
             if ( typeof( window ) !== 'undefined' ) {
                 url = window.location.origin + ( ( window.location.pathname && window.location.pathname.length > 1 ) ? window.location.pathname : '' );
             } else {
@@ -219,19 +244,37 @@ export class AlLocatorMatrix
      *  Resolves a literal URI to a service node.
      */
     public getNodeByURI( targetURI:string ):AlLocationDescriptor|null {
-        for ( let k in this.uriMap ) {
-            const mapping = this.uriMap[k];
-            if ( mapping.matcher.test( targetURI ) ) {
-                let baseUrl = this.getBaseUrl( targetURI );
-                if ( baseUrl !== mapping.location.uri ) {
-                    mapping.location.uri = baseUrl;
-                    mapping.location._fullURI = baseUrl;     // Use this specific base URL for resolving other links to this application type
-                    console.log(`Notice: using [${baseUrl}] as a base URI for location type '${mapping.location.locTypeId}'`);
+        let start = this.timestamp(0);
+        let hit:UriMappingItem = null;
+        Object.entries( this.uriMap ).find( ( [ keyword, candidates ] ) => {
+            if ( targetURI.indexOf( keyword ) !== -1 ) {
+                hit = candidates.find( candidate => {
+                    if ( targetURI.indexOf( candidate.matchExpression ) === 0 ) {
+                        return true;        //  exact match
+                    }
+                    if ( ! candidate.matcher ) {
+                        candidate.matcher = new RegExp( this.escapeLocationPattern( candidate.matchExpression ) );
+                    }
+                    if ( candidate.matcher.test( targetURI ) ) {
+                        return true;
+                    }
+                    return false;
+                } );
+                if ( hit ) {
+                    const baseUrl = this.getBaseUrl( targetURI );
+                    if ( baseUrl !== hit.location.uri ) {
+                        hit.location.uri = baseUrl;
+                        console.log(`Notice: using [${baseUrl}] as a base URI for location type '${hit.location.locTypeId}'`);
+                    }
+                    return true;
                 }
-                return mapping.location;
             }
-        }
-        return null;
+        } );
+
+        let duration = this.timestamp( 1000 ) - start;
+        AlLocatorMatrix.totalTime = AlLocatorMatrix.totalTime ? AlLocatorMatrix.totalTime + duration : duration;
+        AlLocatorMatrix.totalSeeks++;
+        return hit ? hit.location : null;
     }
 
     /**
@@ -242,46 +285,56 @@ export class AlLocatorMatrix
     }
 
     /**
-     *  Recursively resolves the URI of a service node.
+     *  Nested nodes (e.g., an application living inside another application) are official dead, making this method
+     *  @deprecated.
      */
     public resolveNodeURI( node:AlLocationDescriptor, context?:AlLocationContext ):string {
-        if ( node._fullURI ) {
-            return node._fullURI;
-        }
-        let uri = '';
-        if ( node.parentId ) {
-            const parentNode = this.getNode( node.parentId, context );
-            if(parentNode) {
-                uri += this.resolveNodeURI( parentNode, context );
-            }
-        }
-        if ( node.uri ) {
-            uri += node.uri;
-            if ( ! node.parentId ) {
-                //  For historical reasons, some nodes (like auth0) are represented without protocols (e.g., alertlogic-integration.auth0.com instead of https://alertlogic-integration.auth0.com).
-                //  For the purposes of resolving functional links, detect these protocolless domains and add the default https:// protocol to them.
-                if ( uri.indexOf("http") !== 0 ) {
-                    uri = "https://" + uri;
-                }
-            }
-        }
-        node._fullURI = uri;
-        return uri;
+        console.warn("Deprecation warning: please do not use resolveNodeURI directly; just use the location's 'uri' property." );
+        return node.uri;
     }
 
     /**
-     *  Updates the service matrix model with a set of service node descriptors.  Optionally
+     *  Updates the locator matrix model with a set of service node descriptors.  Optionally
      *  calculates which node is the acting node based on its URI.
      *
      *  @param {Array} nodes A list of service node descriptors.
      */
     public setLocations( nodes:AlLocationDescriptor[] ) {
-
-        if ( nodes ) {
-            for ( let i = 0; i < nodes.length; i++ ) {
-                this.saveNode( nodes[i] );
+        nodes.forEach( node => {
+            if ( node.environment && node.residency ) {
+                if ( node.insightLocationId ) {
+                    this.nodeDictionary[`${node.locTypeId}-${node.environment}-${node.residency}-${node.insightLocationId}`] = node;
+                }
+                this.nodeDictionary[`${node.locTypeId}-${node.environment}-${node.residency}`] = node;
             }
-        }
+            if ( node.environment ) {
+                this.nodeDictionary[`${node.locTypeId}-${node.environment}-*`] = node;
+            }
+            this.nodeDictionary[`${node.locTypeId}-*-*`] = node;
+
+            const keyword = node.keyword || node.uri;
+            if ( ! this.uriMap.hasOwnProperty( keyword ) ) {
+                this.uriMap[keyword] = [];
+            }
+
+            this.uriMap[keyword].push( {
+                location: node,
+                matchExpression: node.uri
+            } );
+
+            if ( node.aliases ) {
+                node.aliases.forEach( alias => {
+                    this.uriMap[keyword].push( {
+                        location: node,
+                        matchExpression: alias
+                    } );
+                } );
+            }
+        } );
+
+        Object.entries( this.uriMap ).forEach( ( [ keyword, candidates ] ) => {
+            candidates.sort( ( a, b ) => ( a.location.weight || 0 ) - ( b.location.weight || 0 ) );
+        } );
     }
 
     public setActingUri( actingUri:string|boolean ) {
@@ -292,6 +345,7 @@ export class AlLocatorMatrix
         }
 
         if ( typeof( actingUri ) === 'boolean' ) {
+            /* istanbul ignore else */
             if ( typeof( window ) !== 'undefined' ) {
                 actingUri = window.location.origin + ( ( window.location.pathname && window.location.pathname.length > 1 ) ? window.location.pathname : '' );
             } else {
@@ -316,25 +370,11 @@ export class AlLocatorMatrix
     }
 
     public search( filter:{(node:AlLocationDescriptor):boolean} ):AlLocationDescriptor[] {
-        let results = [];
-        for ( let k in this._nodeMap ) {
-            if ( ! this._nodeMap.hasOwnProperty( k ) ) {
-                continue;
-            }
-            if ( filter( this._nodeMap[k] ) ) {
-                results.push( this._nodeMap[k] );
-            }
-        }
-
-        return results;
+        return Object.values( this.nodeDictionary ).filter( filter );
     }
 
     public findOne( filter:{(node:AlLocationDescriptor):boolean} ):AlLocationDescriptor|null {
-        let results = this.search( filter );
-        if ( results.length === 0 ) {
-            return null;
-        }
-        return results[0];
+        return Object.values( this.nodeDictionary ).find( filter );
     }
 
     /**
@@ -345,6 +385,7 @@ export class AlLocatorMatrix
         this.nodes = {};    //  flush lookup cache
         this.context.insightLocationId = context && context.insightLocationId ? context.insightLocationId : this.context.insightLocationId;
         this.context.accessible = context && context.accessible && context.accessible.length ? context.accessible : this.context.accessible;
+        /* istanbul ignore next */
         if ( this.context.insightLocationId ) {
             let locationNode = this.findOne( n => { return n.insightLocationId === this.context.insightLocationId; } );
             if ( locationNode && locationNode.residency ) {
@@ -363,7 +404,7 @@ export class AlLocatorMatrix
 
     /**
      *  Gets a service node by ID, optionally using a context to refine its selection logic.  The context defaults
-     *  to the service matrix instance's current context; if the default is used, the result of the lookup will be stored
+     *  to the locator matrix instance's current context; if the default is used, the result of the lookup will be stored
      *  for performance optimization.
      *
      *  @param {string} locTypeId The ID of the service node to select.  See al-service-identity.ts for constant values.
@@ -382,8 +423,8 @@ export class AlLocatorMatrix
         let node = null;
 
         if ( insightLocationId ) {
-            if ( this._nodeMap.hasOwnProperty( `${locTypeId}-${environment}-${residency}-${insightLocationId}` ) ) {
-                node = this._nodeMap[`${locTypeId}-${environment}-${residency}-${insightLocationId}`];
+            if ( this.nodeDictionary.hasOwnProperty( `${locTypeId}-${environment}-${residency}-${insightLocationId}` ) ) {
+                node = this.nodeDictionary[`${locTypeId}-${environment}-${residency}-${insightLocationId}`];
             }
         }
 
@@ -391,20 +432,20 @@ export class AlLocatorMatrix
             for ( let i = 0; i < accessible.length; i++ ) {
                 let accessibleLocationId = accessible[i];
                 if ( accessibleLocationId !== insightLocationId ) {
-                    if ( this._nodeMap.hasOwnProperty( `${locTypeId}-${environment}-${residency}-${accessibleLocationId}` ) ) {
-                        node = this._nodeMap[`${locTypeId}-${environment}-${residency}-${accessibleLocationId}`];
+                    if ( this.nodeDictionary.hasOwnProperty( `${locTypeId}-${environment}-${residency}-${accessibleLocationId}` ) ) {
+                        node = this.nodeDictionary[`${locTypeId}-${environment}-${residency}-${accessibleLocationId}`];
                     }
                 }
             }
         }
-        if ( ! node && environment && residency && this._nodeMap.hasOwnProperty( `${locTypeId}-${environment}-${residency}`) ) {
-            node = this._nodeMap[`${locTypeId}-${environment}-${residency}`];
+        if ( ! node && environment && residency && this.nodeDictionary.hasOwnProperty( `${locTypeId}-${environment}-${residency}`) ) {
+            node = this.nodeDictionary[`${locTypeId}-${environment}-${residency}`];
         }
-        if ( ! node && environment && this._nodeMap.hasOwnProperty( `${locTypeId}-${environment}-*`) ) {
-            node = this._nodeMap[`${locTypeId}-${environment}-*`];
+        if ( ! node && environment && this.nodeDictionary.hasOwnProperty( `${locTypeId}-${environment}-*`) ) {
+            node = this.nodeDictionary[`${locTypeId}-${environment}-*`];
         }
-        if ( ! node && this._nodeMap.hasOwnProperty( `${locTypeId}-*-*`) ) {
-            node = this._nodeMap[`${locTypeId}-*-*`];
+        if ( ! node && this.nodeDictionary.hasOwnProperty( `${locTypeId}-*-*`) ) {
+            node = this.nodeDictionary[`${locTypeId}-*-*`];
         }
         if ( node && ! context ) {
             //  Save it in a dictionary for faster lookup next time
@@ -415,48 +456,13 @@ export class AlLocatorMatrix
     }
 
     /**
-     *  Saves a node (including hash lookups).
-     */
-    protected saveNode( node:AlLocationDescriptor ) {
-        if ( node.environment && node.residency ) {
-            if ( node.insightLocationId ) {
-                this._nodeMap[`${node.locTypeId}-${node.environment}-${node.residency}-${node.insightLocationId}`] = node;
-            }
-            this._nodeMap[`${node.locTypeId}-${node.environment}-${node.residency}`] = node;
-        }
-        if ( node.environment ) {
-            this._nodeMap[`${node.locTypeId}-${node.environment}-*`] = node;
-        }
-        this._nodeMap[`${node.locTypeId}-*-*`] = node;
-        this.addUriMapping( node );
-    }
-
-    /**
-     * Adds pattern maches for a node's domain and domain aliases, so that URLs can be easily and efficiently mapped back to their nodes
-     */
-    protected addUriMapping( node:AlLocationDescriptor ) {
-        let pattern:string;
-
-        if ( typeof( node.uri ) === 'string' && node.uri.length > 0 ) {
-            let pattern = this.escapeLocationPattern( node.uri );
-            this.uriMap[pattern] = { matcher: new RegExp( pattern ), location: node };
-        }
-        if ( node.aliases ) {
-            node.aliases.map( alias => {
-                pattern = this.escapeLocationPattern( alias );
-                this.uriMap[pattern] = { matcher: new RegExp( pattern ), location: node };
-            } );
-        }
-    }
-
-    /**
      * Escapes a domain pattern.
      *
      * All normal regex characters are escaped; * is converted to [a-zA-Z0-9_]+; and the whole expression is wrapped in ^....*$.
      */
     protected escapeLocationPattern( uri:string ):string {
         let pattern = "^" + uri.replace(/[-\/\\^$.()|[\]{}]/g, '\\$&');     //  escape all regexp characters except *, add anchor
-        pattern = pattern.replace( /\*/, "[a-zA-Z0-9_]+" );                 //  convert * wildcard into group match with 1 or more characters
+        pattern = pattern.replace( /\*/g, "([a-zA-Z0-9_]+)" );               //  convert * wildcard into group match with 1 or more characters
         pattern += ".*$";                                                   //  add filler and terminus anchor
         return pattern;
     }
@@ -509,5 +515,9 @@ export class AlLocatorMatrix
             //  Location IDs have higher specificity than residency settings, so given defender-uk-newport and residency: US, the residency should be overridden to reflect EMEA.
             this.context.residency = insightLocation.residency;
         }
+    }
+
+    protected timestamp( defaultValue:number ):number {
+        return window && window.hasOwnProperty("performance") ? window.performance.now() : defaultValue;
     }
 }

--- a/src/locator/al-route.types.ts
+++ b/src/locator/al-route.types.ts
@@ -43,6 +43,7 @@ export interface AlRoutingHost
  * debugging, and placeholder or empty menu structures.
  */
 /* tslint:disable:variable-name */
+/* istanbul ignore next */
 export const AlNullRoutingHost = {
     currentUrl: '',
     routeParameters: {} as {[i:string]:string},
@@ -352,7 +353,7 @@ export class AlRoute {
             return false;
         }
 
-        this.baseHREF = AlLocatorService.resolveNodeURI( node );
+        this.baseHREF = node.uri;
         let path = action.path ? action.path : '';
         let missing = false;
         //  Substitute route parameters into the path pattern; fail on missing required parameters,

--- a/src/utility/al-trigger.types.ts
+++ b/src/utility/al-trigger.types.ts
@@ -181,7 +181,7 @@ export class AlSubscriptionGroup
 {
     subscriptions:any[] = [];
 
-    constructor( item:any|any[] ) {
+    constructor( ...item:any|any[] ) {
         if ( item ) {
             this.manage( item );
         }
@@ -191,7 +191,7 @@ export class AlSubscriptionGroup
      * Adds one or more subscriptions (as themselves, in arrays, via callback function, or some mixture of these inputs)
      * to the internal list of managed items.
      */
-    public manage( item:any|any[] ) {
+    public manage( ...item:any|any[] ) {
         if ( typeof( item ) === 'object' && item.length ) {
             item.map( (subitem: any) => this.manage( subitem ) );
             return;

--- a/test/al-errors.spec.ts
+++ b/test/al-errors.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import { describe, before } from 'mocha';
 import { AlAPIServerError, AlResponseValidationError } from '../src/errors';
+import * as sinon from 'sinon';
 
 describe( 'AlAPIServerError', () => {
 
@@ -15,9 +16,24 @@ describe( 'AlAPIServerError', () => {
 } );
 
 describe( 'AlResponseValidationError', () => {
+    let errorStub;
+    beforeEach( () => {
+        errorStub = sinon.stub( console, 'error' );
+    } );
+    afterEach( () => {
+        errorStub.restore();
+    } );
     it( 'should instantiate as expected', () => {
         const error = new AlResponseValidationError( "Some error happened somewhere, somehow", [ { error: true, file: '/file1', line: 120 } ] );
 
         expect( error.message ).to.be.a("string" );
+        expect( error.errors ).to.be.an("array");
+        expect( error.errors.length ).to.equal( 1 );
+
+        const error2 = new AlResponseValidationError( "Blahblahblah" );
+
+        expect( error2.message ).to.be.a("string" );
+        expect( error2.errors ).to.be.an("array");
+        expect( error2.errors.length ).to.equal( 0 );
     } );
 } );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "declarationDir": "./dist/typings/",
     "lib": [
       "es6",
-      "es2015",
+      "es2017",
       "dom"
     ]
   },


### PR DESCRIPTION
This is a series of changes to support a separate "feature branch" environment for
beta navigation-enabled versions of the UI.  This is accomplished by forcing domain recognition to obey a specific prioritization of pattern matching per location type, from
production (first) to local development (last).  Thus more generic PR
branches will not be recognized before the feature branch.

This also includes a restructuring of the data structures used to
recognize domains and their associated context.  Previously, this was
accomplished using a brute-force array of `RegExp.test()` calls.  This
more optimized implementation uses branching by keyword and dynamic
RegExp compilation -- since `String.indexOf` is dramatically faster than
even the simplest regular expression, and most regular expressions will
never need to be compiled in the first place, this increases the overall
performance of domain recognition by a factor of approximately 25
(in local tests, bringing the average lookup down from about 0.65ms to
0.023ms).  I did this mostly so that @motobob won't have to worry so much about regular expressions ;-)

Also ups the ante on testing coverage.