### PR TITLE
TA93701 - US107407 - Better Menu Activation

### DIFF
--- a/src/locator/al-location.dictionary.ts
+++ b/src/locator/al-location.dictionary.ts
@@ -263,7 +263,25 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         locTypeId: AlLocation.Segment,
         uri: 'https://segment.io',
         data: {
-          clientID: 'NJhAMUnCOQJwg8XT4chppHkoCeXApZIt'
+            analyticsKey: 'Ud9VX1aFxXgjg8CnlOBv9k5b6qga9yII'
+        },
+        environment: 'production',
+        residency: 'US'
+    },
+    {
+        locTypeId: AlLocation.Segment,
+        uri: 'https://segment.io',
+        data: {
+            analyticsKey: 'IwB7SmcEFckM6FrHlbQYcg0I75lc93dO'
+        },
+        environment: 'production',
+        residency: 'EMEA'
+    },
+    {
+        locTypeId: AlLocation.Segment,
+        uri: 'https://segment.io',
+        data: {
+            analyticsKey: 'OXe8LjJ0C48IJASuW9Ho37f4o6XCXHIV'
         },
         environment: 'integration'
     },
@@ -271,7 +289,7 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
         locTypeId: AlLocation.Segment,
         uri: 'https://dev.segment.io',
         data: {
-          clientID: 'b1ptaDZMJSUaFmm38ho7p4NH5uHwqheY'
+            analyticsKey: 'b1ptaDZMJSUaFmm38ho7p4NH5uHwqheY'
         },
         environment: 'development'
     },


### PR DESCRIPTION
- Fixes defect where exact match comparison was failing; trims query
  parameters from both URLs.

- Adds two methods to evaluate the deepest `activated: true` item in a
  given menu hierarchy.

- Changes some defaults from `null` to `undefined` for clarity