### PR TITLE
NodeJS Behavioral Enhancements

### DIFF
--- a/src/locator/al-location.dictionary.ts
+++ b/src/locator/al-location.dictionary.ts
@@ -52,6 +52,20 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
     },
 
     /**
+     * Gestapi API locations
+     */
+    {
+        locTypeId: AlLocation.GestaltAPI,
+        uri: 'https://k1t1douoah.execute-api.us-east-1.amazonaws.com/dev',
+        environment: 'production|integration|beta-navigation|beta-nav-prod'
+    },
+    {
+        locTypeId: AlLocation.GestaltAPI,
+        uri: 'http://localhost:3000',
+        environment: 'development'
+    },
+
+    /**
     *  CD14 UI locations.
     */
     {

--- a/src/utility/al-cabinet.ts
+++ b/src/utility/al-cabinet.ts
@@ -38,21 +38,23 @@ export class AlCabinet
      *  @returns {AlCabinet} A cabinet instance that can be used to interrogate/update the data.
      */
 
-    public static persistent( name:string ):AlCabinet {
+    public static persistent( rawName:string ):AlCabinet {
+        const name = `${rawName}_persistent`;
         if ( AlCabinet.openCabinets.hasOwnProperty( name ) ) {
             return AlCabinet.openCabinets[name];
         }
         let cabinet = new AlCabinet( name, {}, AlCabinet.PERSISTENT );
         try {
-            if ( localStorage ) {
+            if ( typeof( localStorage ) !== 'undefined' ) {
                 let content = localStorage.getItem( name );
                 if ( content ) {
                     cabinet.data = JSON.parse( content );
                 }
+            } else {
+                return AlCabinet.local( rawName );
             }
         } catch( e ) {
-            //  really?  A browser that doesn't support localStorage?  Bollocks.
-            console.warn("Unexpected error: could not access localStorage OR failed to parse JSON content found there.", e.toString() );
+            return AlCabinet.local( rawName );
         }
         AlCabinet.openCabinets[name] = cabinet;
         return cabinet;
@@ -66,21 +68,23 @@ export class AlCabinet
      *  @returns {AlCabinet} A cabinet instance that can be used to interrogate/update the data.
      */
 
-    public static ephemeral( name:string ):AlCabinet {
+    public static ephemeral( rawName:string ):AlCabinet {
+        const name = `${rawName}_ephemeral`;
         if ( AlCabinet.openCabinets.hasOwnProperty( name ) ) {
             return AlCabinet.openCabinets[name];
         }
         let cabinet = new AlCabinet( name, {}, AlCabinet.EPHEMERAL );
         try {
-            if ( sessionStorage ) {
+            if ( typeof( sessionStorage ) !== 'undefined' ) {
                 let content = sessionStorage.getItem( name );
                 if ( content ) {
                     cabinet.data = JSON.parse( content );
                 }
+            } else {
+                return AlCabinet.local( rawName );
             }
         } catch( e ) {
-            //  Just, bollocks!
-            console.warn("Unexpected error: could not access localStorage OR failed to parse JSON content found there.", e.toString() );
+            return AlCabinet.local( rawName );
         }
         AlCabinet.openCabinets[name] = cabinet;
         return cabinet;

--- a/test/al-cabinet.spec.ts
+++ b/test/al-cabinet.spec.ts
@@ -9,20 +9,20 @@ describe( 'AlCabinet', () => {
 
     describe('static methods', () => {
         it('should instantiate an AlCabinet of the correct type', () => {
-            const p = AlCabinet.persistent( "persistent.cabinet" );
+            const p = AlCabinet.persistent( "cabinet" );
             expect( p.type ).to.equal( AlCabinet.PERSISTENT );
             expect( p.data ).to.eql( {} );
-            expect( p.name ).to.equal( "persistent.cabinet" );
+            expect( p.name ).to.equal( "cabinet_persistent" );
 
-            const e = AlCabinet.ephemeral( "ephemeral.cabinet" );
+            const e = AlCabinet.ephemeral( "cabinet" );
             expect( e.type ).to.equal( AlCabinet.EPHEMERAL );
             expect( e.data ).to.eql( {} );
-            expect( e.name ).to.equal( "ephemeral.cabinet" );
+            expect( e.name ).to.equal( "cabinet_ephemeral" );
 
-            const l = AlCabinet.local( "local.cabinet" );
+            const l = AlCabinet.local( "cabinet" );
             expect( l.type ).to.equal( AlCabinet.LOCAL );
             expect( l.data ).to.eql( {} );
-            expect( l.name ).to.equal( "local.cabinet" );
+            expect( l.name ).to.equal( "cabinet" );
         } );
 
         it( 'should always return a reference to the same cabinet for a given name', () => {
@@ -88,8 +88,8 @@ describe( 'AlCabinet', () => {
             scabinet.synchronize();
             lcabinet.synchronize();
 
-            expect( localStorage.getItem("testDestroyLS") ).to.be.a('string' );
-            expect( sessionStorage.getItem("testDestroySS") ).to.be.a('string' );
+            expect( localStorage.getItem("testDestroyLS_persistent") ).to.be.a('string' );
+            expect( sessionStorage.getItem("testDestroySS_ephemeral") ).to.be.a('string' );
 
             scabinet.destroy();
             lcabinet.destroy();


### PR DESCRIPTION
A collection of simple changes to support execution in a NodeJS context.

- Absence of localStorage or sessionStorage no longer throws a warning,
  and returns a reference to an in-memory cache instead
- Updated AlCabinet to use a storage-class prefix to avoid clashes in
  buckets with the same name but different classes
- Added support for manually specifying environment/residency for a
  specific location, allowing scripts to target specific environments
selectively