### PR TITLE
NodeJS Behavioral Enhancements

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,9 +27,7 @@
   },
   "types": "./dist/typings/index.d.ts",
   "license": "MIT",
-  "dependencies": {
-    "ajv": "^6.10.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/chai": "^4.2.3",
     "@types/karma": "^3.0.3",

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,4 +19,3 @@ export {
 } from './utility/al-trigger.types';
 
 export * from './locator';
-export * from './schema-validator';

--- a/src/utility/al-cabinet.ts
+++ b/src/utility/al-cabinet.ts
@@ -203,6 +203,7 @@ export class AlCabinet
      *  Destroys the current cabinet, discarding any contents it may have.
      */
     public destroy() {
+        this.data = {};
         try {
             if ( this.type === AlCabinet.PERSISTENT ) {
                 localStorage.removeItem( this.name );


### PR DESCRIPTION
A collection of simple changes to support execution in a NodeJS context.

- Absence of localStorage or sessionStorage no longer throws a warning,
  and returns a reference to an in-memory cache instead
- Updated AlCabinet to use a storage-class prefix to avoid clashes in
  buckets with the same name but different classes
- Added support for manually specifying environment/residency for a
  specific location, allowing scripts to target specific environments
selectively
- Fixed defect where `AlCabinet.destroy()` removed data from storage but
  not from memory!  Hahahahaha
- Remove AJV dependency and schema validator utility (too heavy)