### PR TITLE
Removed local version of GestaltAPI placeholder

### DIFF
--- a/src/locator/al-location.dictionary.ts
+++ b/src/locator/al-location.dictionary.ts
@@ -57,12 +57,7 @@ export const AlLocationDictionary: AlLocationDescriptor[] =
     {
         locTypeId: AlLocation.GestaltAPI,
         uri: 'https://k1t1douoah.execute-api.us-east-1.amazonaws.com/dev',
-        environment: 'production|integration|beta-navigation|beta-nav-prod'
-    },
-    {
-        locTypeId: AlLocation.GestaltAPI,
-        uri: 'http://localhost:3000',
-        environment: 'development'
+        environment: 'production|integration|beta-navigation|beta-nav-prod|development'
     },
 
     /**


### PR DESCRIPTION
The local version of Gestalt APIs can now only be used using an explicit override