### PR TITLE
v1.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/common",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "A collection of lightweight utilities and common types shared across NEPAL libraries and applications based on them.",
   "main": "./dist/umd/index.js",
   "scripts": {

--- a/src/errors/al-error.types.ts
+++ b/src/errors/al-error.types.ts
@@ -30,3 +30,50 @@ export class AlResponseValidationError extends Error
         console.error( message, errors );
     }
 }
+
+/**
+ * Used to indicate an invalid request to a service or API.
+ *
+ * @param message The description of the error
+ * @param inputType Which type of input was malformed (e.g., query parameter, header, data)
+ * @param inputProperty Which data element was malformed (e.g., "filter", "X-AIMS-Auth-Token", ".data.accounts.id")
+ * @param description Additional descriptive content.
+ */
+export class AlBadRequestError extends Error
+{
+    constructor( message:string,
+                 public inputType?:string,
+                 public inputProperty?:string,
+                 public description?:string ) {
+        super( message );
+    }
+}
+
+/**
+ * Used to indicate that the current actor is not authenticated.
+ *
+ * @param message The description of the error
+ * @param authority Which authentication authority made the authentication state claim.  Typically, this will be AIMS.
+ */
+export class AlUnauthenticatedRequestError extends Error
+{
+    constructor( message: string,
+                 public authority:string ) {
+        super( message );
+    }
+}
+
+/**
+ * Used to indicate that the current actor is not authorized to perform a given action.
+ *
+ * @param message A general description of the error or error context.
+ * @param resource The resource that the actor is not authorized to access.
+ */
+export class AlUnauthorizedRequestError extends Error
+{
+    constructor( message: string,
+                 public resource:string ) {
+        super( message );
+    }
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,9 @@
 export {
     AlAPIServerError,
-    AlResponseValidationError
+    AlResponseValidationError,
+    AlBadRequestError,
+    AlUnauthenticatedRequestError,
+    AlUnauthorizedRequestError
 } from './errors/al-error.types';
 
 export { AlStopwatch } from './utility/al-stopwatch';


### PR DESCRIPTION
- Added `reset` and `getCurrentEnvironment()` utility methods to
  AlLocatorMatrix.  `reset()` essentially resets the node cache and any
assumptions about current environment.
- Imported some Error types that are useful for describing API
  responses.