### PR TITLE
Optional Path Defect

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -31,7 +31,8 @@ module.exports = function (config) {
           "es2017",
           "dom"
         ],
-        esModuleInterop: true
+        esModuleInterop: true,
+        sourceMaps: true
       }
     },
 

--- a/src/locator/al-route.types.ts
+++ b/src/locator/al-route.types.ts
@@ -393,11 +393,11 @@ export class AlRoute {
         let path = action.path ? action.path : '';
         let missing = false;
         //  Substitute route parameters into the path pattern; fail on missing required parameters,
-        //  ignore missing optional parameters (denoted by question mark), and trim any trailing slashes and spaces.
-        path = path.replace( /:[a-zA-Z_?]+/g, match => {
+        //  ignore missing optional parameters (denoted by percentage sign), and trim any trailing slashes and spaces.
+        path = path.replace( /:[a-zA-Z_%]+/g, match => {
                 let variableId = match.substring( 1 );
                 let required = true;
-                if ( variableId[variableId.length-1] === '?' ) {
+                if ( variableId[variableId.length-1] === '%' ) {
                     required = false;
                     variableId = variableId.substring( 0, variableId.length - 1 );
                 }

--- a/src/promises/al-behavior-promise.ts
+++ b/src/promises/al-behavior-promise.ts
@@ -13,7 +13,7 @@
  *  This class exposes the basic surface area of a Promise -- it is `then`able -- but allows the resolved value to change
  *  if necessary.
  */
-export class AlBehaviorPromise<ResultType>
+export class AlBehaviorPromise<ResultType=any>
 {
     protected promise:Promise<ResultType>;
     protected resolver?:{(result:ResultType):void};
@@ -49,6 +49,7 @@ export class AlBehaviorPromise<ResultType>
     public resolve( result:ResultType ) {
         this.value = result;
         if ( ! this.fulfilled ) {
+            /* istanbul ignore else */
             if(this.resolver) {
                 this.resolver( result );
             }
@@ -63,6 +64,7 @@ export class AlBehaviorPromise<ResultType>
     public reject( reason:any ) {
         this.value = null;
         if ( ! this.fulfilled ) {
+            /* istanbul ignore else */
             if(this.rejector){
                 this.rejector( reason );
             }

--- a/test/al-route.spec.ts
+++ b/test/al-route.spec.ts
@@ -151,7 +151,7 @@ describe( 'AlRoute', () => {
                 action: {
                     type: 'link',
                     location: AlLocation.OverviewUI,
-                    path: '/#/path/to/:accountId/:userId?/:deploymentId?'
+                    path: '/#/path/to/:accountId/:userId%/:deploymentId%'
                 },
                 properties: {}
             } );
@@ -236,6 +236,21 @@ describe( 'AlRoute', () => {
             menu.refresh();
 
             expect( menu.href ).to.equal( "https://console.overview.alertlogic.com/#/path/2" );
+            expect( menu.activated ).to.equal( true );
+        } );
+        it( "should ignore query parameters", () => {
+            routingHost.currentUrl = "https://console.overview.alertlogic.com/#/queryparams/2?aaid=2&locid=defender-us-denver&filter1=value1&filter2=value2";
+            const menu = new AlRoute( routingHost, {
+                caption: "Test Route",
+                action: {
+                    type: 'link',
+                    location: "cd17:overview",
+                    path: '/#/queryparams/:accountId?locid=defender-us-denver&filter1=value1&aaid=2&filter2=value2'
+                },
+                properties: {}
+            } );
+            menu.refresh();
+
             expect( menu.activated ).to.equal( true );
         } );
     } );

--- a/test/al-stopwatch.spec.ts
+++ b/test/al-stopwatch.spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { describe, before } from 'mocha';
 import { AlBehaviorPromise } from '../src/promises';
 import { AlStopwatch } from '../src/utility';
+import * as sinon from 'sinon';
 
 describe( 'AlStopwatch', () => {
 
@@ -13,6 +14,10 @@ describe( 'AlStopwatch', () => {
 
     beforeEach( () => {
         callCount = 0;
+    } );
+
+    afterEach( () => {
+        afterEach( () => sinon.restore() );
     } );
 
     it("should instantiate via `later`", () => {
@@ -61,6 +66,47 @@ describe( 'AlStopwatch', () => {
                 resolve( true );
             }, 250 );
 
+        } );
+    } );
+
+    describe( "`.again()`", async () => {
+        it( "should not create a new timer if one already exists", () => {
+            stopwatch = AlStopwatch.repeatedly( callback, 10000 );
+            const originalTimer = stopwatch.timer;
+            expect( stopwatch.interval ).to.equal( 10000 );
+            stopwatch.again( 0 );
+            expect( stopwatch.timer ).to.equal( originalTimer );
+            expect( stopwatch.interval ).to.equal( 10000 );
+        } );
+    } );
+
+    describe( "`.reschedule()`", async () => {
+        it( "should call `cancel` and `again`", async () => {
+            stopwatch = AlStopwatch.later( callback );
+            let cancel = sinon.spy( stopwatch, "cancel" );
+            let again = sinon.spy( stopwatch, "again" );
+            stopwatch.reschedule( 10000 );
+            expect( cancel.callCount ).to.equal( 1 );
+            expect( again.callCount ).to.equal( 1 );
+            expect( again.args[0][0] ).to.equal( 10000 );
+        } );
+
+        it( "should default to immediate reexecution", async () => {
+            stopwatch = AlStopwatch.later( callback );
+            let again = sinon.spy( stopwatch, "again" );
+            stopwatch.reschedule();
+            expect( again.callCount ).to.equal( 1 );
+            expect( again.args[0][0] ).to.equal( 0 );
+        } );
+    } );
+
+    describe( "`.reschedule()`", async () => {
+        it( "should call `cancel` and `again`", async () => {
+            stopwatch = AlStopwatch.later( callback );
+            let tick = sinon.spy( stopwatch, "tick" );
+            stopwatch.now();
+            expect( tick.callCount ).to.equal( 1 );
+            expect( callCount ).to.equal( 1 );
         } );
     } );
 


### PR DESCRIPTION
- Fixed a defect in route evaluation/activation checks where the '?'
  character in the query parameter expression was being incorrectly
  swallowed by the parameter injector.
- Excluded a couple of decorative else paths from code coverage
- Added a few new unit tests to improve coverage