### PR TITLE
Added `isPromiseLike` utility function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/common",
-  "version": "1.1.20",
+  "version": "1.1.21",
   "description": "A collection of lightweight utilities and common types shared across NEPAL libraries and applications based on them.",
   "main": "./dist/umd/index.js",
   "scripts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,5 @@
 export * from './errors/al-error.types';
-
-export { AlStopwatch } from './utility/al-stopwatch';
-export { AlCabinet } from './utility/al-cabinet';
-export { AlGlobalizer } from './utility/al-globalizer';
-
 export { AlBehaviorPromise } from './promises/al-behavior-promise';
-
-export {
-    AlTrigger,
-    AlTriggeredEvent,
-    AlTriggeredEventCallback,
-    AlTriggerSubscription,
-    AlTriggerStream,
-    AlSubscriptionGroup
-} from './utility/al-trigger.types';
-
+export * from './utility';
 export * from './locator';
 export * from './cardstack';

--- a/src/utility/index.ts
+++ b/src/utility/index.ts
@@ -2,3 +2,4 @@ export { AlStopwatch } from './al-stopwatch';
 export { AlCabinet } from './al-cabinet';
 export { AlGlobalizer } from './al-globalizer';
 export * from './al-trigger.types';
+export { isPromiseLike } from './is-promise-like';

--- a/src/utility/is-promise-like.ts
+++ b/src/utility/is-promise-like.ts
@@ -1,0 +1,6 @@
+/**
+ * Simple type-guard to check if a given parameter is `PromiseLike`
+ */
+export function isPromiseLike( candidate:any ):candidate is PromiseLike<any> {
+    return typeof( candidate.then ) === 'function';
+}


### PR DESCRIPTION
Because, incredibly, typescript does not provide a built-in type guard for this.

Also bumped version again.