### PR TITLE
v1.1.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/common",
-  "version": "1.1.31",
+  "version": "1.1.32",
   "description": "A collection of lightweight utilities and common types shared across NEPAL libraries and applications based on them.",
   "main": "./dist/umd/index.js",
   "scripts": {

--- a/src/utility/al-stopwatch.ts
+++ b/src/utility/al-stopwatch.ts
@@ -53,6 +53,14 @@ export class AlStopwatch
         return watch;
     }
 
+    public static promise( interval:number ): Promise<void> {
+        return new Promise( ( resolve ) => {
+            AlStopwatch.once( () => {
+                resolve();
+            }, interval );
+        } );
+    }
+
     /**
      *  The timer's tick handler; executes the callback and, for single-fire timers, clears the timer handle.
      */

--- a/test/al-errors.spec.ts
+++ b/test/al-errors.spec.ts
@@ -1,39 +1,92 @@
 import { expect } from 'chai';
 import { describe, before } from 'mocha';
-import { AlAPIServerError, AlResponseValidationError } from '../src/errors';
+import {
+    AlAPIServerError,
+    AlResponseValidationError,
+    AlUnauthenticatedRequestError,
+    AlUnauthorizedRequestError,
+    AlUnimplementedMethodError,
+    AlNotFoundError,
+    AlBadRequestError,
+} from '../src/errors';
 import * as sinon from 'sinon';
 
-describe( 'AlAPIServerError', () => {
-
-    it( 'should instantiate as expected', () => {
-        const error = new AlAPIServerError( "Some error happened somewhere, somehow", "aims", 401 );
-
-        expect( error.message ).to.be.a("string");
-        expect( error.serviceName ).to.equal("aims" );
-        expect( error.statusCode ).to.equal( 401 );
-    } );
-
-} );
-
-describe( 'AlResponseValidationError', () => {
-    let errorStub;
-    beforeEach( () => {
-        errorStub = sinon.stub( console, 'error' );
-    } );
+describe( `Errors`, () => {
     afterEach( () => {
-        errorStub.restore();
+        sinon.reset();
     } );
-    it( 'should instantiate as expected', () => {
-        const error = new AlResponseValidationError( "Some error happened somewhere, somehow", [ { error: true, file: '/file1', line: 120 } ] );
+    describe( 'AlAPIServerError', () => {
 
-        expect( error.message ).to.be.a("string" );
-        expect( error.errors ).to.be.an("array");
-        expect( error.errors.length ).to.equal( 1 );
+        it( 'should instantiate as expected', () => {
+            const error = new AlAPIServerError( "Some error happened somewhere, somehow", "aims", 401 );
 
-        const error2 = new AlResponseValidationError( "Blahblahblah" );
+            expect( error.message ).to.be.a("string");
+            expect( error.serviceName ).to.equal("aims" );
+            expect( error.statusCode ).to.equal( 401 );
+        } );
 
-        expect( error2.message ).to.be.a("string" );
-        expect( error2.errors ).to.be.an("array");
-        expect( error2.errors.length ).to.equal( 0 );
     } );
+
+    describe( 'AlResponseValidationError', () => {
+        it( 'should instantiate as expected', () => {
+            const error = new AlResponseValidationError( "Some error happened somewhere, somehow", [ { error: true, file: '/file1', line: 120 } ] );
+
+            expect( error.message ).to.be.a("string" );
+            expect( error.errors ).to.be.an("array");
+            expect( error.errors.length ).to.equal( 1 );
+
+            const error2 = new AlResponseValidationError( "Blahblahblah" );
+
+            expect( error2.message ).to.be.a("string" );
+            expect( error2.errors ).to.be.an("array");
+            expect( error2.errors.length ).to.equal( 0 );
+        } );
+    } );
+
+    describe( 'AlBadRequestError', () => {
+        it( 'should instantiate as expected', () => {
+            const error = new AlBadRequestError( "You made a bad request", "data", "aggregation.configuration.id", "This value cannot be specified for a creation request" );
+
+            expect( error.httpResponseCode ).to.equal( 400 );
+            expect( error.message ).to.be.a("string" );
+            expect( error.inputType ).to.be.a("string" );
+            expect( error.inputProperty ).to.be.a("string" );
+            expect( error.description ).to.be.a("string" );
+        } );
+    } );
+    describe( 'AlUnauthenticatedRequestError', () => {
+        it( 'should instantiate as expected', () => {
+            const error = new AlUnauthenticatedRequestError( "You cannot login in", "aims" );
+
+            expect( error.httpResponseCode ).to.equal( 401 );
+            expect( error.message ).to.be.a("string" );
+            expect( error.authority ).to.be.a("string" );
+        } );
+    } );
+    describe( 'AlUnauthorizedRequestError', () => {
+        it( 'should instantiate as expected', () => {
+            const error = new AlUnauthorizedRequestError( "You cannot access that stuff", "stuff" );
+
+            expect( error.httpResponseCode ).to.equal( 403 );
+            expect( error.message ).to.be.a("string" );
+            expect( error.resource ).to.be.a("string" );
+        } );
+    } );
+    describe( 'AlUnimplementedMethodError', () => {
+        it( 'should instantiate as expected', () => {
+            const error = new AlUnimplementedMethodError( "No way, Jose" );
+
+            expect( error.httpResponseCode ).to.equal( 501 );
+            expect( error.message ).to.be.a("string" );
+        } );
+    } );
+    describe( 'AlNotFoundError', () => {
+        it( 'should instantiate as expected', () => {
+            const error = new AlNotFoundError( "I don't think so, Bob" );
+
+            expect( error.httpResponseCode ).to.equal( 404 );
+            expect( error.message ).to.be.a("string" );
+        } );
+    } );
+
 } );

--- a/test/al-stopwatch.spec.ts
+++ b/test/al-stopwatch.spec.ts
@@ -69,6 +69,14 @@ describe( 'AlStopwatch', () => {
         } );
     } );
 
+    it("should instantiate and resolve via `promise()`", async () => {
+        let promise = AlStopwatch.promise( 100 );
+        let executed:boolean = false;
+        promise.then( () => executed = true );
+        await promise;
+        expect( executed ).to.equal( true );
+    } );
+
     describe( "`.again()`", async () => {
         it( "should not create a new timer if one already exists", () => {
             stopwatch = AlStopwatch.repeatedly( callback, 10000 );


### PR DESCRIPTION
- Added an `AlStopwatch.promise` static method to use a timer as a promise
- Added unit test coverage for new error types, to get our colors green
  again

@parky128  You may find the new AlStopwatch method useful for your work on the session client