### PR TITLE
Removing '()' from evaluatePathMatch in order to support regular expressions that involves '(parenthesis)'

### DIFF
--- a/src/locator/al-route.types.ts
+++ b/src/locator/al-route.types.ts
@@ -532,7 +532,7 @@ export class AlRoute {
      * Determines whether a path pattern matches the current URL
      */
     evaluatePathMatch( pathMatches:string ) {
-        let pattern = "^.*" + pathMatches.replace(/[{}()|[\]\\\/]/g, '\\$&') + "$";
+        let pattern = "^.*" + pathMatches.replace(/[{}|[\]\\\/]/g, '\\$&') + "$";
         let comparison = new RegExp( pattern );
         return comparison.test( this.host.currentUrl );
     }


### PR DESCRIPTION
With this now we can have a regular expression like:
> /#/deployments-adr/((?!datacenter).).*