### PR TITLE
Navigation Extensions, Phase II

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/common",
-  "version": "1.1.45",
+  "version": "1.2.0",
   "description": "A collection of lightweight utilities and common types shared across NEPAL libraries and applications based on them.",
   "main": "./dist/umd/index.js",
   "scripts": {

--- a/src/locator/al-locator.types.ts
+++ b/src/locator/al-locator.types.ts
@@ -457,8 +457,14 @@ export class AlLocatorMatrix
                     residency: this.actor.residency || this.context.residency
                 } );
             } else {
+                let environment = "production";
+                if ( actingUri.startsWith("http://localhost" ) ) {
+                    environment = "development";
+                } else if ( actingUri.includes("product.dev.alertlogic.com") ) {
+                    environment = "integration";
+                }
                 this.setContext( {
-                    environment:        "production",
+                    environment,
                     residency:          "US",
                     insightLocationId:  undefined,
                     accessible:         undefined

--- a/src/locator/al-route.types.ts
+++ b/src/locator/al-route.types.ts
@@ -526,7 +526,7 @@ export class AlRoute {
             let externals = this.host.evaluate( condition );
             if ( typeof( externals ) === 'boolean' ) {
                 evaluations.push( externals );
-            } else if ( typeof( externals ) === 'object' && externals.hasOwnProperty("length") ) {
+            } else if ( Array.isArray( externals ) ) {
                 evaluations = evaluations.concat( externals );
             }
         }

--- a/src/utility/al-query-evaluator.types.ts
+++ b/src/utility/al-query-evaluator.types.ts
@@ -1,0 +1,224 @@
+/**
+ *  @author Little Beelzebub <knielsen@alertlogic.com>
+ *
+ *  @copyright Alert Logic Inc, 2020
+ */
+
+/**
+ * Describes an objects whose properties can be interrogated/tested using a query's conditions.
+ */
+export interface AlQuerySubject {
+    getPropertyValue( property:string, ns:string ):any;
+}
+
+export class AlQueryEvaluator
+{
+    constructor( public queryDescriptor:any, public id?:string ) {
+    }
+
+    public test( subject:AlQuerySubject, queryDescriptor?:any ):boolean {
+        return this.dispatchOperator( queryDescriptor || this.queryDescriptor, subject );
+    }
+
+    /**
+     *  The following dispatch/evaluate methods are support methods used to actually test a search condition against a target object.
+     *  The evaluative functionality of SQXSearchQuery doesn't necessarily encompass the full range of operators supported by log search.
+     */
+
+    protected dispatchOperator( op:any, subject:AlQuerySubject ):boolean {
+        const operatorKeys = Object.keys( op );
+        this.assert( op, operatorKeys.length === 1, "an operator descriptor should have a single key." );
+        const operatorKey = operatorKeys[0];
+        const operatorValue = op[operatorKey];
+        switch( operatorKey ) {
+            case "and" :
+                return this.evaluateAnd( operatorValue, subject );
+            case "or" :
+                return this.evaluateOr( operatorValue, subject );
+            case "=" :
+                return this.evaluateEquals( operatorValue, subject );
+            case "!=" :
+                return this.evaluateNotEquals( operatorValue, subject );
+            case "<" :
+                return this.evaluateLT( operatorValue, subject );
+            case "<=" :
+                return this.evaluateLTE( operatorValue, subject );
+            case ">" :
+                return this.evaluateGT( operatorValue, subject );
+            case ">=" :
+                return this.evaluateGTE( operatorValue, subject );
+            case "in":
+                return this.evaluateIn( operatorValue, subject );
+            case "not" :
+                return this.evaluateNot( operatorValue, subject );
+            case "isnull" :
+                return this.evaluateIsNull( operatorValue, subject );
+            case "contains" :
+                return this.evaluateContains( operatorValue, subject );
+            case "contains_all" :
+                return this.evaluateContainsAll( operatorValue, subject );
+            case "contains_any" :
+                return this.evaluateContainsAny( operatorValue, subject );
+            default :
+                throw new Error(`Cannot evaluate unknown operator '${operatorKey}'` );
+        }
+    }
+
+    protected evaluateAnd( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length > 0, "`and` descriptor should consist of an array of non-zero length" );
+        let result = true;
+        for ( let i = 0; i < op.length; i++ ) {
+            result = result && this.dispatchOperator( op[i], subject );
+        }
+        return result;
+    }
+
+    protected evaluateOr( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length > 0, "`and` descriptor should consist of an array of non-zero length" );
+        let result = false;
+        for ( let i = 0; i < op.length; i++ ) {
+            result = result || this.dispatchOperator( op[i], subject );
+        }
+        return result;
+    }
+
+    protected evaluateEquals( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length === 2, "`=` descriptor should have two elements" );
+        let property = this.normalizeProperty( op[0] );
+        let actualValue = subject.getPropertyValue( property.id, property.ns );
+        let testValue = op[1];
+
+        return actualValue === testValue;
+    }
+
+    protected evaluateNotEquals( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length === 2, "`!=` descriptor should have two elements" );
+        let property = this.normalizeProperty( op[0] );
+        let actualValue = subject.getPropertyValue( property.id, property.ns );
+        let testValue = op[1];
+
+        return actualValue !== testValue;
+    }
+
+    protected evaluateLT( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length === 2, "`<` descriptor should have two elements" );
+        let property = this.normalizeProperty( op[0] );
+        let actualValue = subject.getPropertyValue( property.id, property.ns );
+        let testValue = op[1];
+
+        return actualValue < testValue;
+    }
+
+    protected evaluateLTE( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length === 2, "`<=` descriptor should have two elements" );
+        let property = this.normalizeProperty( op[0] );
+        let actualValue = subject.getPropertyValue( property.id, property.ns );
+        let testValue = op[1];
+
+        return actualValue <= testValue;
+    }
+
+    protected evaluateGT( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length === 2, "`>` descriptor should have two elements" );
+        let property = this.normalizeProperty( op[0] );
+        let actualValue = subject.getPropertyValue( property.id, property.ns );
+        let testValue = op[1];
+
+        return actualValue > testValue;
+    }
+
+    protected evaluateGTE( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length === 2, "`>=` descriptor should have two elements" );
+        let property = this.normalizeProperty( op[0] );
+        let actualValue = subject.getPropertyValue( property.id, property.ns );
+        let testValue = op[1];
+
+        return actualValue >= testValue;
+    }
+
+    protected evaluateIn( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length === 2, "`in` descriptor should have two elements" );
+        let property = this.normalizeProperty( op[0] );
+        let actualValue = subject.getPropertyValue( property.id, property.ns );
+        let testValues = op[1];
+        this.assert( testValues, testValues.hasOwnProperty("length"), "`in` values clause must be an array" );
+        return testValues.includes( actualValue );
+    }
+
+    protected evaluateNot( op:any, subject:AlQuerySubject ):boolean {
+        return ! this.dispatchOperator( op, subject );
+    }
+
+    protected evaluateIsNull( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length === 1, "`isnull` descriptor should have one element" );
+        let property = this.normalizeProperty( op[0] );
+        let actualValue = subject.getPropertyValue( property.id, property.ns );
+        console.log("Actual value: ", actualValue );
+        return ( actualValue === null || actualValue === undefined );
+    }
+
+    protected evaluateContains( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length === 2, "`contains` descriptor should have two elements" );
+        let property = this.normalizeProperty( op[0] );
+        let actualValues = subject.getPropertyValue( property.id, property.ns );
+        this.assert( actualValues, typeof( actualValues ) === 'object', "`contains` operator must reference a property that is an object or an array" );
+        let testValue = op[1];
+        return actualValues.includes( testValue );
+    }
+
+    protected evaluateContainsAny( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length === 2, "`contains_any` descriptor should have two elements" );
+        let property = this.normalizeProperty( op[0] );
+        let actualValues = subject.getPropertyValue( property.id, property.ns );
+        this.assert( actualValues, typeof( actualValues ) === 'object', "`contains_any` operator must reference a property that is an object or an array" );
+        let testValues = op[1];
+        this.assert( testValues, testValues.hasOwnProperty("length"), "`contains_any` values clause must be an array" );
+        return testValues.reduce( ( alpha:boolean, value:any ) => {
+            if ( actualValues instanceof Array ) {
+                return alpha || actualValues.includes( value );
+            } else {
+                return alpha || ( actualValues.hasOwnProperty( value ) && !! actualValues[value] );
+            }
+        }, false );
+    }
+
+    protected evaluateContainsAll( op:any, subject:AlQuerySubject ):boolean {
+        this.assert( op, op.hasOwnProperty("length") && op.length === 2, "`contains_all` descriptor should have two elements" );
+        let property = this.normalizeProperty( op[0] );
+        let actualValues = subject.getPropertyValue( property.id, property.ns );
+        this.assert( actualValues, typeof( actualValues ) === 'object', "`contains_all` operator must reference a property that is an object or an array" );
+        let testValues = op[1];
+        this.assert( testValues, testValues.hasOwnProperty("length"), "`contains_all` values clause must be an array" );
+        return testValues.reduce( ( alpha:boolean, value:any ) => {
+            if ( actualValues instanceof Array ) {
+                return alpha && actualValues.includes( value );
+            } else {
+                return alpha && ( actualValues.hasOwnProperty( value ) && !! actualValues[value] );
+            }
+        }, true );
+    }
+
+    protected normalizeProperty( descriptor:any ):{ns:string,id:string} {
+        this.assert( descriptor, descriptor.hasOwnProperty("source"), "property reference must include a `source` property" );
+        let propertyRef = descriptor.source;
+        let propertyName;
+        let propertyNs = "default";
+        if ( typeof( propertyRef ) === 'object' && propertyRef.hasOwnProperty("ns") && propertyRef.hasOwnProperty("id") ) {
+            propertyNs = propertyRef.ns;
+            propertyName = propertyRef.id;
+        } else if ( typeof( propertyRef ) === 'string' ) {
+            propertyName = propertyRef;
+        } else {
+            throw new Error(`Invalid property reference [${JSON.stringify(descriptor[0].source)}] in condition descriptor` );
+        }
+        return { ns: propertyNs, id: propertyName };
+    }
+
+    protected assert( subject:any, value:boolean, message:string ) {
+        if ( ! value ) {
+            console.warn("Invalid conditional element", subject );
+            throw new Error( `Failed to interpret condition descriptor: ${message}` );
+        }
+    }
+}
+

--- a/src/utility/al-query-evaluator.types.ts
+++ b/src/utility/al-query-evaluator.types.ts
@@ -35,9 +35,7 @@ type BaseOp =
 type BaseOps = BaseOp[];
 
 type OpAnd = { and: BaseOps };
-
 type OpOr = { or: BaseOps };
-
 type OpEqual = { '=': OpCompare } ;
 type OpNotEqual = { '!=': OpCompare } ;
 type OpLessThan = { '<': OpCompareNum } ;

--- a/src/utility/get-json-path.ts
+++ b/src/utility/get-json-path.ts
@@ -1,0 +1,16 @@
+export function getJsonPath<Type=any>( target:any, path:string|string[], defaultValue?:Type ):Type|undefined {
+    if ( typeof( target ) === 'object' && target !== null ) {
+        if ( typeof( path ) === 'string' ) {
+            path = path.split(".") || [];
+        }
+        let element = path.shift();
+        if ( element && target.hasOwnProperty( element ) ) {
+            if ( path.length === 0 ) {
+                return target[element] as Type;
+            } else {
+                return getJsonPath<Type>( target[element], path, defaultValue );
+            }
+        }
+    }
+    return defaultValue;
+}

--- a/src/utility/index.ts
+++ b/src/utility/index.ts
@@ -1,5 +1,7 @@
 export { AlStopwatch } from './al-stopwatch';
 export { AlCabinet } from './al-cabinet';
 export { AlGlobalizer } from './al-globalizer';
-export * from './al-trigger.types';
 export { isPromiseLike } from './is-promise-like';
+export { getJsonPath } from './get-json-path';
+export * from './al-trigger.types';
+export * from './al-query-evaluator.types';

--- a/test/al-locator.spec.ts
+++ b/test/al-locator.spec.ts
@@ -126,8 +126,7 @@ describe( 'AlLocatorMatrix', () => {
             expect( locator['actingUri'] ).to.equal( undefined );
             expect( locator['actor'] ).to.equal( undefined );
 
-            //  Context inferred from default URL, which won't be recognized
-            locator.setActingUri( true );
+            locator.setActingUri( "https://console.overview.alertlogic.com" );
             let actor = locator.getActingNode();
             let context = locator.getContext();
             expect( context.environment ).to.equal( "production" );

--- a/test/al-query-evaluator.spec.ts
+++ b/test/al-query-evaluator.spec.ts
@@ -1,0 +1,61 @@
+import { expect } from 'chai';
+import { describe, before } from 'mocha';
+import * as sinon from 'sinon';
+import { AlQuerySubject, AlQueryEvaluator } from '../src/utility';
+
+class MockQueryable implements AlQuerySubject
+{
+    constructor( public data:any ) {
+    }
+
+    getPropertyValue( property:string, ns:string ):any {
+        if ( this.data.hasOwnProperty( ns ) ) {
+            return this.extract( this.data[ns], property.split(".") );
+        } else {
+            return this.extract( this.data, property.split(".") );
+        }
+    }
+
+    extract( cursor:any, propertyPath:string[] ):any {
+        if ( propertyPath.length === 0 ) {
+            return null;
+        }
+        const property = propertyPath.shift();
+        if ( ! cursor.hasOwnProperty( property ) ) {
+            return null;
+        }
+        if ( propertyPath.length === 0 ) {
+            return cursor[property];
+        } else {
+            return this.extract( cursor[property], propertyPath );
+        }
+    }
+}
+
+describe( `AlQueryEvaluator`, () => {
+    let queryable:MockQueryable;
+    beforeEach( () => {
+        queryable = new MockQueryable( {
+            "default": {
+                "a": true,
+                "b": 1,
+                "c": "textValue",
+                "d": [ "red", "green", "blue" ],
+                "e": null,
+            }
+        } );
+    } );
+    afterEach( () => {
+        sinon.reset();
+    } );
+    describe( 'test', () => {
+        it( 'should evaluate basic queries properly', () => {
+            let query = new AlQueryEvaluator( {"and":[{"and":[{"and":[{"and":[{"and":[{"and":[{"=":[{"source":"a"},true]},{"=":[{"source":"b"},1]}]},{"=":[{"source":"c"},"textValue"]}]},{"contains_any":[{"source":"d"},["red","yellow","brown"]]}]},{"contains_all":[{"source":"d"},["red","green","blue"]]}]},{"isnull":[{"source":"e"}]}]},{"=":[{"source":"e"},null]}]} );
+            expect( query.test( queryable ) ).to.equal( true );
+
+            let query2 = new AlQueryEvaluator({"or":[{"=":[{"source":"a"},false]},{"<":[{"source":"b"},1]},{"=":[{"source":"c"},"snarfblatt"]},{"contains_any":[{"source":"d"},["pink","orange","purple"]]},{"contains_all":[{"source":"d"},["red","green","blurple"]]},{"isnull":[{"source":"a"}]}]});
+            expect( query2.test( queryable ) ).to.equal( false );
+
+        } );
+    } );
+} );

--- a/test/al-query-evaluator.spec.ts
+++ b/test/al-query-evaluator.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { describe, before } from 'mocha';
+import { describe } from 'mocha';
 import * as sinon from 'sinon';
 import { AlQuerySubject, AlQueryEvaluator } from '../src/utility';
 
@@ -20,7 +20,7 @@ class MockQueryable implements AlQuerySubject
         if ( propertyPath.length === 0 ) {
             return null;
         }
-        const property = propertyPath.shift();
+        const property = propertyPath.shift() as string;
         if ( ! cursor.hasOwnProperty( property ) ) {
             return null;
         }
@@ -50,10 +50,120 @@ describe( `AlQueryEvaluator`, () => {
     } );
     describe( 'test', () => {
         it( 'should evaluate basic queries properly', () => {
-            let query = new AlQueryEvaluator( {"and":[{"and":[{"and":[{"and":[{"and":[{"and":[{"=":[{"source":"a"},true]},{"=":[{"source":"b"},1]}]},{"=":[{"source":"c"},"textValue"]}]},{"contains_any":[{"source":"d"},["red","yellow","brown"]]}]},{"contains_all":[{"source":"d"},["red","green","blue"]]}]},{"isnull":[{"source":"e"}]}]},{"=":[{"source":"e"},null]}]} );
+            let query = new AlQueryEvaluator({
+                "and": [
+                    {
+                        "and": [
+                            {
+                                "and": [
+                                    {
+                                        "and": [
+                                            {
+                                                "and": [
+                                                    {
+                                                        "and": [
+                                                            {
+                                                                "=": [
+                                                                    { "source": "a" },
+                                                                    true
+                                                                ]
+                                                            },
+                                                            {
+                                                                "=": [
+                                                                    { "source": "b" },
+                                                                    1
+                                                                ]
+                                                            }
+                                                        ]
+                                                    },
+                                                    {
+                                                        "=": [
+                                                            { "source": "c" },
+                                                            "textValue"
+                                                        ]
+                                                    }
+                                                ]
+                                            },
+                                            {
+                                                "contains_any": [
+                                                    { "source": "d" },
+                                                    [
+                                                        "red",
+                                                        "yellow",
+                                                        "brown"
+                                                    ]
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "contains_all": [
+                                            { "source": "d" },
+                                            [
+                                                "red",
+                                                "green",
+                                                "blue"
+                                            ]
+                                        ]
+                                    }
+                                ]
+                            },
+                            { "isnull": [{ "source": "e" }] }
+                        ]
+                    },
+                    {
+                        "=": [
+                            { "source": "e" },
+                            null
+                        ]
+                    }
+                ]
+            });
             expect( query.test( queryable ) ).to.equal( true );
 
-            let query2 = new AlQueryEvaluator({"or":[{"=":[{"source":"a"},false]},{"<":[{"source":"b"},1]},{"=":[{"source":"c"},"snarfblatt"]},{"contains_any":[{"source":"d"},["pink","orange","purple"]]},{"contains_all":[{"source":"d"},["red","green","blurple"]]},{"isnull":[{"source":"a"}]}]});
+            let query2 = new AlQueryEvaluator({
+                "or": [
+                    {
+                        "=": [
+                            { "source": "a" },
+                            false
+                        ]
+                    },
+                    {
+                        "<": [
+                            { "source": "b" },
+                            1
+                        ]
+                    },
+                    {
+                        "=": [
+                            { "source": "c" },
+                            "snarfblatt"
+                        ]
+                    },
+                    {
+                        "contains_any": [
+                            { "source": "d" },
+                            [
+                                "pink",
+                                "orange",
+                                "purple"
+                            ]
+                        ]
+                    },
+                    {
+                        "contains_all": [
+                            { "source": "d" },
+                            [
+                                "red",
+                                "green",
+                                "blurple"
+                            ]
+                        ]
+                    },
+                    { "isnull": [{ "source": "a" }] }
+                ]
+            });
             expect( query2.test( queryable ) ).to.equal( false );
 
         } );


### PR DESCRIPTION
- Bumped version to 1.2.0 
- Updated `AlRouteCondition` to support assertions about acting entitlements,
  primary entitlements, current environment, experience (global), authentication
  state, and freeform queries (the minor version bump is because entitlements has changed from a string to a string array; this format change is supported/normalized by the corresponding PR to nepal-ng-common-components, but is not fully compatible with previous constructs).
- Added utility class to support evaluation of search_lib style query
  constructs against arbitrary targets.
- Added utility function to extract data from a given JSON path.
- Added better handling for unknown domains: assume development for localhost, integration for anything with .product.dev.alertlogic.com in it, even if it isn't explicitly recognized.
- Added support for condition result caching in `AlRoutingHost`