### PR TITLE
US115354 - Client Side Error Handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@al/common",
-  "version": "1.2.13",
+  "version": "1.2.14",
   "description": "A collection of lightweight utilities and common types shared across NEPAL libraries and applications based on them.",
   "main": "./dist/umd/index.js",
   "scripts": {


### PR DESCRIPTION
Extended try/catch blocks to include the entirety of both `start` and
`continue` methods, and update the cardstack's `error` property to allow
strings or Errors to be passed.

[US115354 in Rally](https://rally1.rallydev.com/#/340101526180d/detail/userstory/379382863612)